### PR TITLE
Fix preset initialization

### DIFF
--- a/src/cljss/core.cljs
+++ b/src/cljss/core.cljs
@@ -5,11 +5,11 @@
 (defn- get-default [obj] (.-default obj))
 
 (defn setup
+  "Setup JSS. Plugins must be initialized if adding them to setup."
   ([]
-   (setup (get-default preset)))
-  ([plugins]
-   (.setup (get-default jss)
-           plugins)))
+   (.setup (get-default jss) ((get-default preset))))
+  ([& plugins]
+   (apply (aget (get-default jss) "use") plugins)))
 
 (defn classes
   [styles]


### PR DESCRIPTION
Looks like the problem was that the default preset was not initialized before added to setup and for some reason, was silently ignored. I have not tested the second arity but should work according to the jss [docs.](https://github.com/cssinjs/jss/blob/master/docs/setup.md#setup-with-custom-plugins)
  